### PR TITLE
fix(awg): routeThroughXray — needRestart для AWG, iif policy routing,…

### DIFF
--- a/internal/awg/instance_test.go
+++ b/internal/awg/instance_test.go
@@ -225,29 +225,109 @@ func TestClientSubnet(t *testing.T) {
 	}
 }
 
-func TestRenderServerConf_RouteThroughXrayHasRouteToTun(t *testing.T) {
+func TestAwgRouteTable(t *testing.T) {
+	if got := awgRouteTable(1); got != 1001 {
+		t.Fatalf("awgRouteTable(1) = %d, want 1001", got)
+	}
+	if got := awgRouteTable(42); got != 1042 {
+		t.Fatalf("awgRouteTable(42) = %d, want 1042", got)
+	}
+}
+
+// routeThroughXray steers client-originated traffic into the Xray TUN via an
+// iif policy rule and a per-inbound table. The route itself (default dev tunN)
+// is owned by the reconcile loop — tunN does not exist yet at PostUp time and
+// is recreated on every Xray restart, so a one-shot PostUp cannot own it.
+func TestRenderServerConf_RouteThroughXrayPolicyRouting(t *testing.T) {
 	inst := Instance{
 		Id: 1, Ifname: "awg1", Port: 47000, PrivateKey: "k", MTU: 1320,
 		Address: "10.8.0.1/24", RouteThroughXray: true,
 	}
 	conf := renderServerConf(inst)
-	if !strings.Contains(conf, "PostUp") {
-		t.Errorf("PostUp must be present when routeThroughXray is set, got:\n%s", conf)
+	mustContain := []string{
+		"PostUp",
+		"ip rule add iif awg1 lookup 1001",
+		"ip_forward",
+		"net.ipv4.conf.awg1.rp_filter=2",
+		"FORWARD -i awg1 -j ACCEPT",
+		"FORWARD -o awg1 -j ACCEPT",
+		"FORWARD -i tun1 -j ACCEPT",
+		"FORWARD -o tun1 -j ACCEPT",
 	}
-	if !strings.Contains(conf, "tun1") {
-		t.Errorf("PostUp must reference tun1 (Xray TUN inbound), got:\n%s", conf)
+	for _, s := range mustContain {
+		if !strings.Contains(conf, s) {
+			t.Errorf("conf missing %q\nConf:\n%s", s, conf)
+		}
 	}
-	if !strings.Contains(conf, "ip rule add from 10.8.0.0/24 lookup 100") {
-		t.Errorf("PostUp must add policy routing rule for AWG subnet, got:\n%s", conf)
+	mustNotContain := []string{
+		"MASQUERADE",
+		"ip route replace 10.8.0.0/24",
+		"ip rule add from",
+		"sleep",
 	}
-	if !strings.Contains(conf, "table 100") {
-		t.Errorf("PostUp must use routing table 100, got:\n%s", conf)
+	for _, s := range mustNotContain {
+		if strings.Contains(conf, s) {
+			t.Errorf("conf must not contain %q\nConf:\n%s", s, conf)
+		}
 	}
-	if strings.Contains(conf, "MASQUERADE") {
-		t.Errorf("PostUp must NOT contain MASQUERADE when routeThroughXray, got:\n%s", conf)
+	postDown := ""
+	for _, line := range strings.Split(conf, "\n") {
+		if strings.HasPrefix(line, "PostDown") {
+			postDown = line
+		}
 	}
-	if !strings.Contains(conf, "ip_forward") {
-		t.Errorf("PostUp must enable ip_forward even with routeThroughXray, got:\n%s", conf)
+	for _, s := range []string{"ip rule del iif awg1 lookup 1001", "ip route flush table 1001"} {
+		if !strings.Contains(postDown, s) {
+			t.Errorf("PostDown missing %q, got %q", s, postDown)
+		}
+	}
+}
+
+func TestNatPostUpPostDown_RouteThroughXrayPerInbound(t *testing.T) {
+	inst := Instance{
+		Id: 7, Ifname: "awg7", Port: 47007, PrivateKey: "k", MTU: 1320,
+		Address: "10.9.0.1/24", RouteThroughXray: true,
+	}
+	postUp, postDown := natPostUpPostDown(inst)
+	for _, s := range []string{"iif awg7 lookup 1007", "FORWARD -i tun7"} {
+		if !strings.Contains(postUp, s) {
+			t.Errorf("PostUp missing %q, got %q", s, postUp)
+		}
+	}
+	for _, s := range []string{"iif awg7 lookup 1007", "flush table 1007"} {
+		if !strings.Contains(postDown, s) {
+			t.Errorf("PostDown missing %q, got %q", s, postDown)
+		}
+	}
+}
+
+func TestEnsureXrayRoutingCmds(t *testing.T) {
+	inst := Instance{Id: 3, Ifname: "awg3", RouteThroughXray: true}
+	cmds := ensureXrayRoutingCmds(inst)
+	want := []string{
+		"ip route replace default dev tun3 table 1003",
+		"sysctl -qw net.ipv4.conf.tun3.rp_filter=2",
+	}
+	if len(cmds) != len(want) {
+		t.Fatalf("expected %d commands, got %d: %v", len(want), len(cmds), cmds)
+	}
+	for i, w := range want {
+		if strings.Join(cmds[i], " ") != w {
+			t.Errorf("cmd %d = %q, want %q", i, strings.Join(cmds[i], " "), w)
+		}
+	}
+}
+
+func TestRuleMissing(t *testing.T) {
+	withRule := "32765:\tfrom all iif awg3 lookup 1003\n"
+	if ruleMissing(withRule, 1003) {
+		t.Error("rule present in output must not be reported missing")
+	}
+	if !ruleMissing("", 1003) {
+		t.Error("empty output means the rule is missing")
+	}
+	if !ruleMissing("32765:\tfrom all iif awg3 lookup 100\n", 1003) {
+		t.Error("a different table must not satisfy the check")
 	}
 }
 

--- a/internal/awg/manager.go
+++ b/internal/awg/manager.go
@@ -12,6 +12,7 @@ import (
 	"net/netip"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -61,7 +62,11 @@ func (m *Manager) Ensure(inst Instance) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.sweepOrphansLocked()
-	return m.ensureLocked(inst)
+	if err := m.ensureLocked(inst); err != nil {
+		return err
+	}
+	m.ensureXrayRouting(inst)
+	return nil
 }
 
 // sweepOrphansLocked kills awg interfaces and tun2socks processes left running
@@ -142,7 +147,9 @@ func (m *Manager) Reconcile(desired []Instance) {
 	for _, inst := range desired {
 		if err := m.ensureLocked(inst); err != nil {
 			logger.Warningf("awg: reconcile failed for inbound %d: %v", inst.Id, err)
+			continue
 		}
+		m.ensureXrayRouting(inst)
 	}
 }
 
@@ -247,6 +254,72 @@ func writeServerConfigFile(inst Instance) error {
 	return os.WriteFile(configPathForID(inst.Id), []byte(conf), 0o600)
 }
 
+// tunNameFor returns the name of the Xray TUN inbound device paired with an
+// AWG inbound id (awgN → tunN), matching injectAwgEgress in the web service.
+func tunNameFor(id int) string {
+	return fmt.Sprintf("tun%d", id)
+}
+
+// awgRouteTable returns the per-inbound policy-routing table that carries the
+// default route into tunN. Offset by 1000 to stay clear of the tables admins
+// commonly hand-allocate (100, 200, …) and of the reserved 253-255 range.
+func awgRouteTable(id int) int {
+	return 1000 + id
+}
+
+// ensureXrayRoutingCmds returns the idempotent commands that keep one routed
+// instance converged: the per-inbound table's default route pinned into tunN
+// and loose reverse-path filtering on tunN (Xray writes replies with public
+// source addresses into it, which strict rp_filter would drop).
+func ensureXrayRoutingCmds(inst Instance) [][]string {
+	tunName := tunNameFor(inst.Id)
+	return [][]string{
+		{"ip", "route", "replace", "default", "dev", tunName, "table", strconv.Itoa(awgRouteTable(inst.Id))},
+		{"sysctl", "-qw", "net.ipv4.conf." + tunName + ".rp_filter=2"},
+	}
+}
+
+// ruleMissing reports whether `ip rule show` output lacks a lookup into the
+// given routing table. Suffix-matched per line so table 100 does not shadow
+// 1003.
+func ruleMissing(ruleOutput string, table int) bool {
+	needle := "lookup " + strconv.Itoa(table)
+	for _, line := range strings.Split(ruleOutput, "\n") {
+		if strings.HasSuffix(strings.TrimSpace(line), needle) {
+			return false
+		}
+	}
+	return true
+}
+
+// ensureXrayRouting converges the kernel routing state a routed instance
+// needs around the Xray-owned tunN device. It must run periodically, not once:
+// the table's default route dies with tunN on every Xray restart, and PostUp
+// cannot install it because tunN does not exist yet when awg-quick runs. A
+// no-op (and silent) while tunN is absent — Xray may be down or restarting.
+func (m *Manager) ensureXrayRouting(inst Instance) {
+	if !inst.RouteThroughXray {
+		return
+	}
+	tunName := tunNameFor(inst.Id)
+	if err := exec.CommandContext(context.Background(), "ip", "link", "show", tunName).Run(); err != nil {
+		return
+	}
+	for _, args := range ensureXrayRoutingCmds(inst) {
+		if out, err := exec.CommandContext(context.Background(), args[0], args[1:]...).CombinedOutput(); err != nil {
+			logger.Warningf("awg: ensure xray routing (%s): %v\n%s", strings.Join(args, " "), err, string(out))
+		}
+	}
+	table := awgRouteTable(inst.Id)
+	out, err := exec.CommandContext(context.Background(), "ip", "rule", "show", "iif", inst.Ifname).Output()
+	if err != nil || !ruleMissing(string(out), table) {
+		return
+	}
+	if out2, err2 := exec.CommandContext(context.Background(), "ip", "rule", "add", "iif", inst.Ifname, "lookup", strconv.Itoa(table)).CombinedOutput(); err2 != nil {
+		logger.Warningf("awg: re-add policy rule for %s: %v\n%s", inst.Ifname, err2, string(out2))
+	}
+}
+
 // clientSubnet extracts the network prefix (e.g. "10.8.0.0/24") from the
 // server's tunnel Address (e.g. "10.8.0.1/24"). Returns empty when Address is
 // unset or unparseable, in which case NAT rules are skipped.
@@ -272,47 +345,53 @@ func clientSubnet(address string) string {
 // both directions. This mirrors pumbaX/awg-multi-script.
 //
 // With routeThroughXray: Xray owns the routing via an injected TUN inbound
-// (tunN). But awg-quick up runs BEFORE Xray creates tunN, so we cannot add the
-// route at PostUp time directly. Instead PostUp spawns a background retry-loop
-// (sh -c 'for i in ... do ip route add ... && break; sleep 1; done &') that
-// waits for tunN to appear, then routes the AWG subnet into it. Xray picks the
-// packets off tunN and applies its routing rules. No MASQUERADE here — Xray
-// handles outbound NAT via its own freedom/direct outbound. PostDown removes
-// the route (best-effort, tunN may already be gone).
+// (tunN). PostUp wires the static half — forwarding, loose reverse-path
+// filtering on awgN, FORWARD accepts for both awgN and tunN legs, and an iif
+// policy rule sending everything received on awgN into the per-inbound table
+// awgRouteTable(id). The iif selector (not `from <subnet>`) matches only
+// forwarded client traffic, so server-originated packets sourced from the
+// awgN address still reach clients directly. The table's default route into
+// tunN is NOT set here: tunN does not exist yet at PostUp time and is
+// recreated on every Xray restart, so ensureXrayRouting (called from the
+// reconcile loop) owns it. No MASQUERADE here — Xray terminates the flows in
+// its TUN netstack and dials out with the server's own address.
 func natPostUpPostDown(inst Instance) (postUp, postDown string) {
 	subnet := clientSubnet(inst.Address)
 	if subnet == "" {
 		return "", ""
 	}
 	iface := inst.Ifname
-	tunName := fmt.Sprintf("tun%d", inst.Id)
+	tunName := tunNameFor(inst.Id)
 
 	if inst.RouteThroughXray {
-		// Policy routing: send all traffic FROM the AWG subnet into tunN via
-		// a dedicated routing table (100). This is needed because a plain
-		// `ip route replace <subnet> dev tunN` only routes packets DESTINED to
-		// the subnet through tunN, not packets FROM it. Client packets have
-		// src=10.8.0.x, dst=internet — we need them to go through tunN so
-		// Xray can process them. A separate table avoids disturbing the main
-		// route table (which still needs to deliver return traffic to awgN).
-		// The retry loop waits for tunN to appear (Xray creates it after
-		// awg-quick up). ip rule + ip route in table 100 are idempotent
-		// (replace, not add) so re-runs are safe.
+		table := awgRouteTable(inst.Id)
 		postUp = fmt.Sprintf(
 			"echo 1 > /proc/sys/net/ipv4/ip_forward; "+
-				"ip rule del from %s lookup 100 2>/dev/null || true; "+
-				"ip rule add from %s lookup 100; "+
-				"sh -c 'for i in 1 2 3 4 5 6 7 8 9 10; do "+
-				"ip link show %s >/dev/null 2>&1 && "+
-				"ip route replace default dev %s table 100 2>/dev/null && break; "+
-				"sleep 1; done' &",
-			subnet, subnet,
-			tunName, tunName,
+				"sysctl -qw net.ipv4.conf.%s.rp_filter=2; "+
+				"iptables -C FORWARD -i %s -j ACCEPT 2>/dev/null || "+
+				"iptables -A FORWARD -i %s -j ACCEPT; "+
+				"iptables -C FORWARD -o %s -j ACCEPT 2>/dev/null || "+
+				"iptables -A FORWARD -o %s -j ACCEPT; "+
+				"iptables -C FORWARD -i %s -j ACCEPT 2>/dev/null || "+
+				"iptables -A FORWARD -i %s -j ACCEPT; "+
+				"iptables -C FORWARD -o %s -j ACCEPT 2>/dev/null || "+
+				"iptables -A FORWARD -o %s -j ACCEPT; "+
+				"ip rule del iif %s lookup %d 2>/dev/null || true; "+
+				"ip rule add iif %s lookup %d",
+			iface,
+			iface, iface, iface, iface,
+			tunName, tunName, tunName, tunName,
+			iface, table, iface, table,
 		)
 		postDown = fmt.Sprintf(
-			"ip rule del from %s lookup 100 2>/dev/null || true; "+
-				"ip route flush table 100 2>/dev/null || true",
-			subnet,
+			"ip rule del iif %s lookup %d 2>/dev/null || true; "+
+				"ip route flush table %d 2>/dev/null || true; "+
+				"iptables -D FORWARD -i %s -j ACCEPT 2>/dev/null || true; "+
+				"iptables -D FORWARD -o %s -j ACCEPT 2>/dev/null || true; "+
+				"iptables -D FORWARD -i %s -j ACCEPT 2>/dev/null || true; "+
+				"iptables -D FORWARD -o %s -j ACCEPT 2>/dev/null || true",
+			iface, table, table,
+			iface, iface, tunName, tunName,
 		)
 		return postUp, postDown
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,7 +23,7 @@ var name string
 // LUCX-HOOK: LucX-UI fork version suffix appended to the upstream base version
 // so the dashboard advertises our build (e.g. "3.5.0-lucx.7") instead of the
 // bare upstream "3.5.0". Bump this with each LucX release.
-const lucxVersion = "lucx.29"
+const lucxVersion = "lucx.30"
 
 // buildCommit and buildDate are injected at build time via `-ldflags -X` for
 // CI per-commit (dev channel) builds; see .github/workflows/release.yml. They

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -16,7 +16,7 @@ func TestGetPanelVersion(t *testing.T) {
 
 	// LUCX-HOOK: dev builds carry the LucX suffix, so the expected form is
 	// "<lucxVersion>+dev+<commit>" (e.g. "lucx.22+dev+1d1128cf").
-	wantDev := "lucx.29+dev+1d1128cf"
+	wantDev := "lucx.30+dev+1d1128cf"
 	buildCommit = "1d1128cf"
 	if got := GetPanelVersion(); got != wantDev {
 		t.Fatalf("dev build: GetPanelVersion = %q, want %q", got, wantDev)

--- a/internal/web/service/inbound.go
+++ b/internal/web/service/inbound.go
@@ -737,6 +737,23 @@ func mtprotoRoutesThroughXray(inbound *model.Inbound) bool {
 	return parsed.RouteThroughXray
 }
 
+// awgRoutesThroughXray reports whether an AWG inbound is configured to egress
+// through the core's router (the TUN bridge in §xray.go). Such inbounds live
+// only in the generated config, so every mutation of one must force a config
+// regen — the kernel sidecar push alone never touches Xray.
+func awgRoutesThroughXray(inbound *model.Inbound) bool {
+	if inbound == nil || inbound.Protocol != model.AWG {
+		return false
+	}
+	var parsed struct {
+		RouteThroughXray bool `json:"routeThroughXray"`
+	}
+	if err := json.Unmarshal([]byte(inbound.Settings), &parsed); err != nil {
+		return false
+	}
+	return parsed.RouteThroughXray
+}
+
 func settingsRouteXrayPort(parsed map[string]any) int {
 	switch v := parsed["routeXrayPort"].(type) {
 	case float64:
@@ -1009,10 +1026,11 @@ func (s *InboundService) AddInbound(inbound *model.Inbound) (*model.Inbound, boo
 		postCommitApply()
 	}
 
-	// A routed mtproto inbound is not an Xray inbound itself, so the runtime
-	// push above only (re)starts the mtg sidecar. The egress SOCKS bridge lives
-	// in the generated config, so force a regen to wire it in.
-	if mtprotoRoutesThroughXray(inbound) {
+	// A routed mtproto or AWG inbound is not an Xray inbound itself, so the
+	// runtime push above only (re)starts its sidecar. The egress bridge (SOCKS
+	// loopback for mtproto, TUN for AWG) lives in the generated config, so
+	// force a regen to wire it in.
+	if mtprotoRoutesThroughXray(inbound) || awgRoutesThroughXray(inbound) {
 		needRestart = true
 	}
 
@@ -1104,8 +1122,8 @@ func (s *InboundService) DelInbound(id int) (bool, error) {
 			}
 		}
 	}
-	// Drop the egress SOCKS bridge a routed mtproto inbound left in the config.
-	if mtprotoRoutesThroughXray(&ib) {
+	// Drop the egress bridge a routed mtproto or AWG inbound left in the config.
+	if mtprotoRoutesThroughXray(&ib) || awgRoutesThroughXray(&ib) {
 		needRestart = true
 	}
 	return needRestart, nil
@@ -1188,6 +1206,12 @@ func (s *InboundService) SetInboundEnable(id int, enable bool) (bool, error) {
 	}
 	inbound.Enable = enable
 
+	// A routed mtproto/AWG inbound keeps its egress bridge (SOCKS loopback or
+	// TUN) only in the generated config, so flipping enable in either
+	// direction must regenerate it — the runtime push below only touches the
+	// sidecar process, never Xray.
+	routedBridge := mtprotoRoutesThroughXray(inbound) || awgRoutesThroughXray(inbound)
+
 	needRestart := false
 	rt, push, _, perr := s.nodePushPlan(inbound)
 	if perr != nil {
@@ -1218,7 +1242,7 @@ func (s *InboundService) SetInboundEnable(id int, enable bool) (bool, error) {
 		needRestart = true
 	}
 	if !enable {
-		return needRestart, nil
+		return needRestart || routedBridge, nil
 	}
 
 	runtimeInbound, err := s.buildRuntimeInboundForAPI(db, inbound)
@@ -1230,7 +1254,7 @@ func (s *InboundService) SetInboundEnable(id int, enable bool) (bool, error) {
 		logger.Debug("SetInboundEnable: AddInbound on", rt.Name(), "failed:", err)
 		needRestart = true
 	}
-	return needRestart, nil
+	return needRestart || routedBridge, nil
 }
 
 func (s *InboundService) UpdateInbound(inbound *model.Inbound) (*model.Inbound, bool, error) {
@@ -1263,6 +1287,7 @@ func (s *InboundService) UpdateInbound(inbound *model.Inbound) (*model.Inbound, 
 	// inbound keeps a stable egress port (reusing the one already stored).
 	oldProtocol := oldInbound.Protocol
 	oldRoutedMtproto := mtprotoRoutesThroughXray(oldInbound)
+	oldRoutedAwg := awgRoutesThroughXray(oldInbound)
 	if err := s.normalizeMtprotoXrayPort(inbound, oldInbound.Settings); err != nil {
 		return inbound, false, err
 	}
@@ -1468,9 +1493,10 @@ func (s *InboundService) UpdateInbound(inbound *model.Inbound) (*model.Inbound, 
 			}
 		}
 		// (Re)generate the Xray config whenever routing was or is now enabled, so
-		// the egress SOCKS bridge is added, moved, or dropped to match the new
-		// settings.
-		if mtprotoRoutesThroughXray(inbound) || oldRoutedMtproto {
+		// the egress bridge (SOCKS or TUN) is added, moved, or dropped to match
+		// the new settings.
+		if mtprotoRoutesThroughXray(inbound) || oldRoutedMtproto ||
+			awgRoutesThroughXray(inbound) || oldRoutedAwg {
 			needRestart = true
 		}
 		return nil

--- a/internal/web/service/inbound_awg_test.go
+++ b/internal/web/service/inbound_awg_test.go
@@ -1,0 +1,134 @@
+package service
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/mhsanaei/3x-ui/v3/internal/database"
+	"github.com/mhsanaei/3x-ui/v3/internal/database/model"
+	"github.com/mhsanaei/3x-ui/v3/internal/web/runtime"
+)
+
+func TestAwgRoutesThroughXray(t *testing.T) {
+	cases := map[string]struct {
+		ib   *model.Inbound
+		want bool
+	}{
+		"routed":   {&model.Inbound{Protocol: model.AWG, Settings: `{"routeThroughXray":true}`}, true},
+		"off":      {&model.Inbound{Protocol: model.AWG, Settings: `{"routeThroughXray":false}`}, false},
+		"absent":   {&model.Inbound{Protocol: model.AWG, Settings: `{}`}, false},
+		"non-awg":  {&model.Inbound{Protocol: model.VLESS, Settings: `{"routeThroughXray":true}`}, false},
+		"bad json": {&model.Inbound{Protocol: model.AWG, Settings: `{nope`}, false},
+		"nil":      {nil, false},
+	}
+	for name, c := range cases {
+		if got := awgRoutesThroughXray(c.ib); got != c.want {
+			t.Fatalf("%s: got %v want %v", name, got, c.want)
+		}
+	}
+}
+
+// initAwgServiceTest gives each test a throwaway DB and pins the runtime
+// manager to nil so nodePushPlan takes the push=false path — no sidecar
+// process is ever started from a unit test.
+func initAwgServiceTest(t *testing.T) {
+	t.Helper()
+	dbDir := t.TempDir()
+	t.Setenv("XUI_DB_FOLDER", dbDir)
+	if err := database.InitDB(filepath.Join(dbDir, "x-ui.db")); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(func() { _ = database.CloseDB() })
+	prev := runtime.GetManager()
+	runtime.SetManager(nil)
+	t.Cleanup(func() { runtime.SetManager(prev) })
+}
+
+func routedAwgTestInbound(port int) *model.Inbound {
+	return &model.Inbound{
+		UserId:         1,
+		Port:           port,
+		Protocol:       model.AWG,
+		Remark:         "awg-routed",
+		Enable:         true,
+		Settings:       `{"privateKey":"test-priv","address":"10.8.0.1/24","routeThroughXray":true,"outboundTag":"warp","clients":[]}`,
+		StreamSettings: `{}`,
+		Sniffing:       `{}`,
+	}
+}
+
+// The TUN egress inbound lives only in the generated Xray config, so creating
+// a routed AWG inbound must force a config regen — exactly like a routed
+// mtproto inbound does. Without needRestart the TUN device never appears and
+// client traffic leaves un-NATed through the default route.
+func TestAddInbound_RoutedAwgForcesXrayRegen(t *testing.T) {
+	initAwgServiceTest(t)
+	svc := &InboundService{}
+	_, needRestart, err := svc.AddInbound(routedAwgTestInbound(40199))
+	if err != nil {
+		t.Fatalf("AddInbound: %v", err)
+	}
+	if !needRestart {
+		t.Fatal("adding a routed AWG inbound must set needRestart so injectAwgEgress runs")
+	}
+}
+
+func TestAddInbound_PlainAwgDoesNotForceRegen(t *testing.T) {
+	initAwgServiceTest(t)
+	svc := &InboundService{}
+	ib := routedAwgTestInbound(40198)
+	ib.Settings = `{"privateKey":"test-priv","address":"10.8.0.1/24","routeThroughXray":false,"clients":[]}`
+	_, needRestart, err := svc.AddInbound(ib)
+	if err != nil {
+		t.Fatalf("AddInbound: %v", err)
+	}
+	if needRestart {
+		t.Fatal("a kernel-routed AWG inbound must not force an Xray restart")
+	}
+}
+
+func TestDelInbound_RoutedAwgForcesXrayRegen(t *testing.T) {
+	initAwgServiceTest(t)
+	ib := routedAwgTestInbound(40197)
+	ib.Enable = false
+	ib.Tag = "awg-del-test"
+	if err := database.GetDB().Create(ib).Error; err != nil {
+		t.Fatalf("create inbound: %v", err)
+	}
+	svc := &InboundService{}
+	needRestart, err := svc.DelInbound(ib.Id)
+	if err != nil {
+		t.Fatalf("DelInbound: %v", err)
+	}
+	if !needRestart {
+		t.Fatal("deleting a routed AWG inbound must set needRestart so the TUN inbound is dropped from the config")
+	}
+}
+
+// Disabling a routed AWG inbound must drop its TUN inbound from the generated
+// config, so needRestart has to come back true. This runs with a real local
+// runtime: the disable path only calls awg.Manager.Remove, a no-op for an
+// interface that was never started, so no awg-quick process is ever spawned.
+// The enable direction would start a kernel interface and is deliberately left
+// to the on-server verification, as is UpdateInbound (whose nodePushPlan
+// fallback forces needRestart=true whenever the runtime cannot be reached,
+// masking the routing check from a unit test).
+func TestSetInboundEnable_DisableRoutedAwgForcesXrayRegen(t *testing.T) {
+	initAwgServiceTest(t)
+	runtime.SetManager(runtime.NewManager(runtime.LocalDeps{APIPort: func() int { return 0 }}))
+	t.Cleanup(func() { runtime.SetManager(nil) })
+
+	ib := routedAwgTestInbound(40196)
+	ib.Tag = "awg-enable-test"
+	if err := database.GetDB().Create(ib).Error; err != nil {
+		t.Fatalf("create inbound: %v", err)
+	}
+	svc := &InboundService{}
+	needRestart, err := svc.SetInboundEnable(ib.Id, false)
+	if err != nil {
+		t.Fatalf("SetInboundEnable: %v", err)
+	}
+	if !needRestart {
+		t.Fatal("disabling a routed AWG inbound must set needRestart so the TUN inbound is dropped from the config")
+	}
+}

--- a/internal/web/service/xray.go
+++ b/internal/web/service/xray.go
@@ -617,24 +617,34 @@ func injectMtprotoEgress(cfg *xray.Config, inbound *model.Inbound) {
 // flows its decrypted IP packets into so Xray routing rules apply. Unlike the
 // mtproto SOCKS bridge (TCP from userspace), AWG produces raw IP packets from
 // the kernel module, so a TUN inbound is the correct sink. The TUN device name
-// is derived from the AWG interface name (awgN → tunN) and the MTU/gateway are
-// sourced from the inbound's stored settings.
+// is derived from the AWG interface name (awgN → tunN); the gateway comes from
+// awgTunGateway, not from the inbound's tunnel address.
 const awgEgressTunSettingsFmt = `{"name":"%s","mtu":%d,"gateway":["%s"],"userLevel":0}`
+
+// awgTunGateway returns the address Xray assigns to tunN. It must lie outside
+// the AWG tunnel subnet — sharing it would give the kernel two connected
+// routes for the same prefix and pull the reply path toward tunN — and must
+// differ between routed inbounds, whose TUN devices coexist. A per-id /30
+// under 10.254/16 satisfies both against the 10.8.0.0/24-style defaults the
+// panel hands out.
+func awgTunGateway(id int) string {
+	return fmt.Sprintf("10.254.%d.1/30", id%254)
+}
 
 // injectAwgEgress wires one routed AWG inbound into the generated config: it
 // appends a TUN inbound (tagged with the inbound's own tag) and, when an
 // outbound is selected, prepends a routing rule sending that tag to it. Both
-// live only in the generated config — the stored template is untouched — and
-// both are hot-appliable, so toggling routing never forces a full Xray
-// restart. Mirrors injectMtprotoEgress but uses a TUN inbound instead of a
-// loopback SOCKS bridge, because AWG traffic is raw IP from a kernel module,
-// not TCP from a userspace daemon.
+// live only in the generated config — the stored template is untouched — so
+// every change to a routed AWG inbound must force a config regen (see
+// awgRoutesThroughXray in §inbound.go); the kernel-side sidecar push alone
+// never reaches Xray. Mirrors injectMtprotoEgress but uses a TUN inbound
+// instead of a loopback SOCKS bridge, because AWG traffic is raw IP from a
+// kernel module, not TCP from a userspace daemon.
 func injectAwgEgress(cfg *xray.Config, inbound *model.Inbound) {
 	var parsed struct {
 		RouteThroughXray bool   `json:"routeThroughXray"`
 		OutboundTag      string `json:"outboundTag"`
 		MTU              int    `json:"mtu"`
-		Address          string `json:"address"`
 	}
 	if err := json.Unmarshal([]byte(inbound.Settings), &parsed); err != nil {
 		return
@@ -689,20 +699,22 @@ func injectAwgEgress(cfg *xray.Config, inbound *model.Inbound) {
 	if mtu == 0 {
 		mtu = 1320
 	}
-	// The TUN device needs its own IP in CIDR format (Xray rejects bare IPs:
-	// "invalid CIDR address"). We use a fixed /30 in a separate subnet
-	// (10.254.254.0/30) so it never conflicts with the AWG tunnel subnet
-	// (typically 10.8.0.0/24). If both subnets overlapped, the kernel would
-	// auto-add conflicting connected routes and return packets from Xray
-	// could loop back into tunN instead of going to awgN.
 	tunName := fmt.Sprintf("tun%d", inbound.Id)
-	tunSettings := fmt.Sprintf(awgEgressTunSettingsFmt, tunName, mtu, "10.254.254.1/30")
+	tunSettings := fmt.Sprintf(awgEgressTunSettingsFmt, tunName, mtu, awgTunGateway(inbound.Id))
 	cfg.InboundConfigs = append(cfg.InboundConfigs, xray.InboundConfig{
 		Protocol: "tun",
 		Settings: json_util.RawMessage(tunSettings),
+		Sniffing: json_util.RawMessage(awgEgressTunSniffing),
 		Tag:      tag,
 	})
 }
+
+// awgEgressTunSniffing lets the router match domain rules against AWG flows:
+// without it the TUN inbound only ever exposes destination IPs, so geosite/
+// domain rules silently never fire for routed AWG traffic. routeOnly keeps
+// the sniffed SNI/Host a routing-time hint — the dial target stays the IP the
+// client resolved, so egress behavior is unchanged.
+const awgEgressTunSniffing = `{"enabled":true,"destOverride":["http","tls","quic"],"routeOnly":true}`
 
 // END LUCX-HOOK
 

--- a/internal/web/service/xray_config_inject_test.go
+++ b/internal/web/service/xray_config_inject_test.go
@@ -408,8 +408,8 @@ func TestInjectAwgEgress_WithOutbound(t *testing.T) {
 	if settings.MTU != 1320 {
 		t.Errorf("expected mtu 1320, got %d", settings.MTU)
 	}
-	if len(settings.Gateway) != 1 || settings.Gateway[0] != "10.254.254.1/30" {
-		t.Errorf("expected gateway [10.254.254.1/30] (fixed /30 to avoid subnet conflict), got %v", settings.Gateway)
+	if len(settings.Gateway) != 1 || settings.Gateway[0] != "10.254.1.1/30" {
+		t.Errorf("expected gateway [10.254.1.1/30] (per-inbound /30 outside the AWG subnet), got %v", settings.Gateway)
 	}
 	// Routing rule prepended with outboundTag.
 	var r egressRouting
@@ -480,8 +480,62 @@ func TestInjectAwgEgress_DefaultMTUAndGateway(t *testing.T) {
 	if settings.MTU != 1320 {
 		t.Errorf("expected default mtu 1320, got %d", settings.MTU)
 	}
-	if len(settings.Gateway) != 1 || settings.Gateway[0] != "10.254.254.1/30" {
-		t.Errorf("expected default gateway [10.254.254.1/30] (fixed /30), got %v", settings.Gateway)
+	if len(settings.Gateway) != 1 || settings.Gateway[0] != "10.254.1.1/30" {
+		t.Errorf("expected default gateway [10.254.1.1/30] (per-inbound /30), got %v", settings.Gateway)
+	}
+}
+
+// The router can only match domain rules against AWG traffic when the TUN
+// inbound sniffs the SNI/Host out of the flows. routeOnly keeps the sniffed
+// domain a routing-time hint: the dial target stays the IP the client
+// resolved, so enabling sniffing never changes where traffic actually goes.
+func TestInjectAwgEgress_SniffingRouteOnly(t *testing.T) {
+	cfg := egressTestConfig()
+	injectAwgEgress(cfg, awgInbound("inbound-awg-1", `{"routeThroughXray":true,"mtu":1320}`))
+	ib := cfg.InboundConfigs[1]
+	var sniffing struct {
+		Enabled      bool     `json:"enabled"`
+		DestOverride []string `json:"destOverride"`
+		RouteOnly    bool     `json:"routeOnly"`
+	}
+	if err := json.Unmarshal(ib.Sniffing, &sniffing); err != nil {
+		t.Fatalf("injected TUN inbound must carry a sniffing block, got %q: %v", ib.Sniffing, err)
+	}
+	if !sniffing.Enabled || !sniffing.RouteOnly {
+		t.Fatalf("sniffing must be enabled with routeOnly, got %+v", sniffing)
+	}
+	want := []string{"http", "tls", "quic"}
+	if len(sniffing.DestOverride) != len(want) {
+		t.Fatalf("destOverride = %v, want %v", sniffing.DestOverride, want)
+	}
+	for i, w := range want {
+		if sniffing.DestOverride[i] != w {
+			t.Fatalf("destOverride = %v, want %v", sniffing.DestOverride, want)
+		}
+	}
+}
+
+// Two routed AWG inbounds must not share a TUN address or a routing table, so
+// the gateway is derived from the inbound id, in step with tunN and table
+// 1000+N on the awg side.
+func TestInjectAwgEgress_PerInboundGateway(t *testing.T) {
+	cfg := egressTestConfig()
+	ib := awgInbound("inbound-awg-7", `{"routeThroughXray":true,"mtu":1400}`)
+	ib.Id = 7
+	injectAwgEgress(cfg, ib)
+	got := cfg.InboundConfigs[len(cfg.InboundConfigs)-1]
+	var settings struct {
+		Name    string   `json:"name"`
+		Gateway []string `json:"gateway"`
+	}
+	if err := json.Unmarshal(got.Settings, &settings); err != nil {
+		t.Fatal(err)
+	}
+	if settings.Name != "tun7" {
+		t.Errorf("expected tun name tun7, got %s", settings.Name)
+	}
+	if len(settings.Gateway) != 1 || settings.Gateway[0] != "10.254.7.1/30" {
+		t.Errorf("expected gateway [10.254.7.1/30], got %v", settings.Gateway)
 	}
 }
 

--- a/progress.md
+++ b/progress.md
@@ -424,6 +424,30 @@ PostDown = iptables -t nat -D POSTROUTING -s 10.8.0.0/24 -o eth0 -j MASQUERADE; 
 
 ---
 
+## Фикс: routeThroughXray для AWG — needRestart, iif policy routing, reconcile-ensure (2026-07-16, v3.5.0-lucx.30)
+
+**Симптом:** при включении тумблера «Маршрутизировать через Xray» на AWG-инбаунде у клиентов пропадал интернет (диагностика на runode: journalctl 18:21–18:24 — awg1 перезапущен, Xray не тронут, tun1 не создан).
+
+**Рут-козы (три независимые):**
+
+1. **Тоггл не перегенерировал конфиг Xray.** `needRestart` поднимался только для MTProto (`mtprotoRoutesThroughXray`) — AWG-путь обновления шёл целиком в kernel-sidecar (`runtime/local.go`), Xray не перезапускался, `injectAwgEgress` не выполнялся → TUN-инбаунд не появлялся. При этом PostUp routeThroughXray-ветки убирает MASQUERADE → трафик клиентов уходил в eth0 с приватным src без NAT → мёртвый интернет.
+2. **Маршрут в таблице умирал при каждом рестарте Xray** (tunN пересоздаётся, device-bound route удаляется ядром), а одноразовый PostUp retry-loop (10×1с) проигрывал гонку 30-секундному cron-рестарту и не переживал последующие рестарты.
+3. **Фиксированные таблица (100) и gateway (10.254.254.1/30)** ломали конфигурацию с двумя routed-инбаундами (затирали друг друга), а `from <subnet>`-правило дополнительно захватывало server-originated трафик с адресом awgN.
+
+**Решение:**
+
+- `inbound.go`: `awgRoutesThroughXray` (зеркало mtproto-хелпера) + `needRestart` в `AddInbound`/`DelInbound`/`UpdateInbound` (`oldRoutedAwg`)/`SetInboundEnable` (в enable-тоггл добавлен и mtproto — та же латентная дыра).
+- `manager.go`: PostUp — статическая половина: ip_forward, loose rp_filter на awgN, FORWARD accepts для awgN и tunN, `ip rule add iif awgN lookup 1000+N` (iif вместо from — не трогает server-originated трафик). Маршрутом владеет `ensureXrayRouting` из reconcile-цикла (каждые 10с): `ip route replace default dev tunN table 1000+N` + loose rp_filter на tunN + самовосстановление ip rule. Молча no-op, пока tunN отсутствует.
+- `xray.go` `injectAwgEgress`: gateway per-inbound `10.254.(N%254).1/30` (`awgTunGateway`) вместо фиксированного; на TUN-инбаунд навешен sniffing `{http,tls,quic, routeOnly:true}` — без него доменные/geosite-правила роутера для AWG-трафика молча не срабатывали (роутер видел только IP). `routeOnly` оставляет снифф домена подсказкой для роутинга, адрес назначения не подменяется.
+
+**Дизайн проверен вживую** на runode до реализации: netns-клиент → veth → `ip rule iif` → tun99 (реальный xray-бинарник) → freedom: ICMP 2/2, HTTPS 200, в xray-логе dispatcher → routing → freedom с IP сервера.
+
+**Тесты:** `TestAwgRouteTable`, `TestRenderServerConf_RouteThroughXrayPolicyRouting`, `TestNatPostUpPostDown_RouteThroughXrayPerInbound`, `TestEnsureXrayRoutingCmds`, `TestRuleMissing` (awg); `TestAwgRoutesThroughXray`, `TestAddInbound_RoutedAwgForcesXrayRegen`, `TestAddInbound_PlainAwgDoesNotForceRegen`, `TestDelInbound_RoutedAwgForcesXrayRegen`, `TestSetInboundEnable_DisableRoutedAwgForcesXrayRegen`, `TestInjectAwgEgress_PerInboundGateway` (service). Полные сьюты awg + web/service зелёные (`-shuffle=on`).
+
+**lucxVersion** → `lucx.30`.
+
+---
+
 ## Заметки
 
 - v3.5.0 релиз 2026-07-12 (вчера)


### PR DESCRIPTION
# fix(awg): routeThroughXray — needRestart, iif policy routing, reconcile-ensure маршрута, sniffing

## Симптом

При включении «Маршрутизировать через Xray» на AWG-инбаунде у клиентов пропадает интернет. Дополнительно: смена поля «Исходящий» не применяется к работающему Xray («в тестах маршрут правильный, на практике — нет»), а доменные правила маршрутизации для AWG-трафика не срабатывают вовсе.

## Корневые причины (четыре независимые)

### 1. Тоггл не перегенерирует конфиг Xray

`needRestart` поднимается только для MTProto (`mtprotoRoutesThroughXray` в `AddInbound`/`DelInbound`/`UpdateInbound`). Путь обновления AWG-инбаунда идёт целиком в kernel-sidecar (`runtime/local.go` → `awg.Manager`), Xray не перезапускается → `injectAwgEgress` не выполняется → TUN-инбаунд (`tunN`) не появляется в работающем конфиге. При этом PostUp routeThroughXray-ветки не ставит MASQUERADE (Xray же должен владеть трафиком) → пакеты клиентов уходят в default-интерфейс с приватным src без NAT → интернет мёртв.

Тот же механизм даёт «залипание» конфига: смена `outboundTag` или выключение тумблера сохраняется в БД, но работающий Xray продолжает жить со старым инжектированным правилом (например, «весь awg-трафик → каскадный outbound») до случайного рестарта.

### 2. Маршрут в per-inbound таблице не переживает рестарты Xray

`tunN` пересоздаётся при каждом рестарте Xray, а device-bound маршрут (`default dev tunN table X`) удаляется ядром вместе с устройством. Одноразовый PostUp retry-loop (10×1с) выполняется только при `awg-quick up` и, кроме того, проигрывает гонку 30-секундному cron-рестарту Xray: цикл истекает раньше, чем cron успевает перезапустить Xray и создать `tunN`. После любого рестарта Xray правило `ip rule` остаётся, но указывает в пустую таблицу → lookup проваливается в main → трафик уходит без NAT → тихая смерть туннеля.

### 3. Фиксированные таблица и gateway ломают мульти-инбаунд

Таблица `100` и gateway `10.254.254.1/30` общие для всех routed-инбаундов: два инбаунда затирают друг другу default-маршрут и делят один IP на разных TUN-устройствах. Плюс правило `from <subnet>` захватывает и server-originated трафик с адресом awgN (например, ответы панели клиентам).

### 4. Роутер не видит домены AWG-трафика

На инжектируемом TUN-инбаунде не включён sniffing → роутер матчит только IP. Любые `domain:`/`geosite:`-правила для AWG-трафика молча не срабатывают — сценарий «выборочный каскад по доменам» не работает в принципе.

## Что сделано

**`internal/web/service/inbound.go`**
- `awgRoutesThroughXray` (зеркало mtproto-хелпера).
- `needRestart` в `AddInbound`, `DelInbound`, `UpdateInbound` (со снапшотом `oldRoutedAwg` — регенерация и при выключении) и `SetInboundEnable`. В enable-тоггле закрыта та же латентная дыра и для mtproto.

**`internal/awg/manager.go`**
- PostUp — только статическая половина: `ip_forward`, loose `rp_filter` на awgN, FORWARD accepts для awgN и tunN, `ip rule add iif awgN lookup 1000+N`. Селектор `iif` вместо `from` — матчит только форвардящийся клиентский трафик.
- Маршрутом владеет `ensureXrayRouting`, вызываемый из reconcile-цикла (каждые 10с): `ip route replace default dev tunN table 1000+N`, loose `rp_filter` на tunN, самовосстановление `ip rule`. Тихий no-op, пока tunN отсутствует. Это закрывает и гонку с cron-рестартом, и потерю маршрута при любых последующих рестартах Xray.
- PostDown чистит правило и таблицу.
- Хелперы `tunNameFor`, `awgRouteTable`, `ensureXrayRoutingCmds`, `ruleMissing` — чистые функции под тесты.

**`internal/web/service/xray.go`**
- `awgTunGateway(id)`: per-inbound gateway `10.254.(N%254).1/30` вместо фиксированного — TUN-адреса и таблицы больше не пересекаются между инбаундами.
- На TUN-инбаунд навешен sniffing `{"enabled":true,"destOverride":["http","tls","quic"],"routeOnly":true}`. `routeOnly` — снифф домена используется только для матчинга правил, адрес назначения не подменяется (dial идёт на IP, который резолвил клиент), т.е. egress-семантика не меняется.

**Версия**: `lucx.30` (+ секция в `progress.md`).

## Как проверялось

Юнит-тесты (все red→green, полные сьюты `internal/awg` + `internal/web/service` + `internal/config` зелёные с `-shuffle=on`):
- `TestAwgRouteTable`, `TestRenderServerConf_RouteThroughXrayPolicyRouting`, `TestNatPostUpPostDown_RouteThroughXrayPerInbound`, `TestEnsureXrayRoutingCmds`, `TestRuleMissing`;
- `TestAwgRoutesThroughXray`, `TestAddInbound_RoutedAwgForcesXrayRegen`, `TestAddInbound_PlainAwgDoesNotForceRegen`, `TestDelInbound_RoutedAwgForcesXrayRegen`, `TestSetInboundEnable_DisableRoutedAwgForcesXrayRegen`;
- `TestInjectAwgEgress_PerInboundGateway`, `TestInjectAwgEgress_SniffingRouteOnly` (+ обновлённые существующие).

Живая проверка на VPS (Ubuntu 24.04, kernel amneziawg, Xray 26.7.11):
- тумблер ON: `tunN` создаётся, `ip rule iif awgN lookup 1000+N` и `default dev tunN` на месте; OFF: PostDown чистит правило/таблицу, MASQUERADE-режим возвращается;
- устойчивость: `kill -9` процесса Xray → `tunN` пересоздан, маршрут восстановлен reconcile-циклом за ≤10с;
- сквозной тест реальным AWG-клиентом (netns, ключи клиента инбаунда): handshake через обфускацию, ICMP и HTTPS через цепочку awgN → policy routing → tunN → Xray router → outbound;
- сниффинг: при пустом «Исходящем» и правиле `domain → blocked` запрос с TLS SNI на IP режется правилом, тот же IP без SNI проходит — доменные правила для AWG-трафика работают, выборочный каскад по доменам реализуем.

## Заметки

- Семантика «явный outboundTag = весь трафик инбаунда в него» (prepended-правило) сохранена; выборочная маршрутизация — через пустой «Исходящий» + правила шаблона, в согласии с 92ac860e/1426524f.
- Конфликтов с текущим main нет (ветка rebased поверх 1426524f).