### PR TITLE
fix(awg): Zod клиентская схема — расширяет WireguardClientSchema

### DIFF
--- a/frontend/src/schemas/protocols/inbound/awg.ts
+++ b/frontend/src/schemas/protocols/inbound/awg.ts
@@ -5,6 +5,14 @@
 // SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 
 import { z } from 'zod';
+import { WireguardClientSchema } from './wireguard';
+
+// AWG Client = WireGuard client + legacy поля (id/password)
+// Переиспользуем WireguardClientSchema чтобы не дублировать comment/limitIp/etc.
+const AwgClientSchema = WireguardClientSchema.extend({
+  id: z.string().optional(),
+  password: z.string().optional(),
+});
 
 // AWG (AmneziaWG) inbound. Served by a kernel-interface sidecar managed by
 // internal/awg, not Xray, so it has no stream settings. The settings blob
@@ -46,22 +54,7 @@ export const AwgInboundSettingsSchema = z.object({
   // tunnel address are stored so a full client .conf and share-link can be
   // rendered (mirroring WireGuard). Legacy inbounds stored id/password; the
   // backend maps these to publicKey/preSharedKey.
-  clients: z
-    .array(
-      z.object({
-        publicKey: z.string().default(''),
-        privateKey: z.string().optional(),
-        preSharedKey: z.string().optional(),
-        allowedIPs: z.array(z.string()).default([]),
-        keepAlive: z.number().int().min(0).optional(),
-        email: z.string(),
-        enable: z.boolean().default(true),
-        // Legacy fields (old inbounds): id = public key, password = PSK.
-        id: z.string().optional(),
-        password: z.string().optional(),
-      }),
-    )
-    .default([]),
+  clients: z.array(AwgClientSchema).default([]),
   // When set, the AWG kernel interface's decrypted packets flow into a TUN
   // inbound injected into the Xray config so egress obeys routing rules.
   // Mirrors mtproto's routeThroughXray but uses a TUN inbound (raw IP from


### PR DESCRIPTION
AWG = WG + обфускация, клиенты хранят те же поля.
Без comment/limitIp/totalGB/expiryTime/tgId/subId/reset Zod стрипал их при .parse() → UpdateInbound → SyncInbound затирал ClientRecord.Comment пустой строкой.

fix: импорт WireguardClientSchema + .extend() на id/password. Клиентская схема AWG теперь зеркалит WireGuard.

## Summary

<!-- What does this PR do? One or two sentences. -->

## Why

<!--
What problem does this solve, or what use case does it enable?
Link related issues here: "Closes #123", "Refs #456".
-->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Documentation
- [ ] Tests only
- [ ] Build / CI / tooling
- [ ] Other

## Areas affected

- [ ] Frontend (UI / panel pages)
- [ ] Backend (API endpoints, login, settings)
- [ ] Xray config generation
- [ ] Subscription (share links / Clash / JSON)
- [ ] Statistics / traffic counters
- [ ] Database / migrations
- [ ] Install / upgrade script
- [ ] Docker image
- [ ] Multi-node (sub-nodes)
- [ ] Telegram bot

## How was this tested?

<!--
Concrete steps the reviewer can repeat. For UI changes: which page,
which actions, which browser. For backend: which endpoint, which payload,
which response. Mention any new unit/integration tests added.
-->

## Screenshots / recordings

<!-- Required for UI changes. Drag images or GIFs here. Remove if N/A. -->

## Breaking changes

<!--
Does this change require existing users to update their config, run a
migration, or change their API calls? If yes, describe the migration path.
Write "None" if there are no breaking changes.
-->

## Checklist

- [x] I tested the change locally and confirmed the described behavior.
- [ ] I added or updated tests for the new behavior (when applicable).
- [ ] `go build ./...` and the test suite pass locally.
- [x] For frontend changes: `npm run lint`, `npm run typecheck`, and `npm run build` pass.
- [ ] I updated the Wiki / README / API docs if user-facing behavior changed.
- [ ] My commits follow the project's existing message style.
- [ ] I have no unrelated changes mixed into this PR.
